### PR TITLE
Fix coordinate decoding order

### DIFF
--- a/Sources/MapTilerSDK/Helpers/Coordinates.swift
+++ b/Sources/MapTilerSDK/Helpers/Coordinates.swift
@@ -34,8 +34,8 @@ extension CLLocationCoordinate2D: Codable {
 
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        let latitude = try container.decode(CLLocationDegrees.self)
         let longitude = try container.decode(CLLocationDegrees.self)
+        let latitude = try container.decode(CLLocationDegrees.self)
 
         self = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }

--- a/Tests/MapTilerSDKTests/MapTilerSDKTests.swift
+++ b/Tests/MapTilerSDKTests/MapTilerSDKTests.swift
@@ -47,4 +47,15 @@ struct HelperTests {
         }
 
     }
+
+    @Test func clLocationCoordinate2D_codable_roundTrip() async throws {
+        let original = CLLocationCoordinate2D(latitude: 10.0, longitude: 20.0)
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(CLLocationCoordinate2D.self, from: data)
+
+        #expect(decoded.latitude == original.latitude)
+        #expect(decoded.longitude == original.longitude)
+    }
 }


### PR DESCRIPTION
## Summary
- fix order of decoded coordinates to match GeoJSON LngLat
- add Codable round-trip test for CLLocationCoordinate2D

## Testing
- `swift test` *(fails: no such module 'CoreLocation')*


------
https://chatgpt.com/codex/tasks/task_b_68a3315c53e483318d51c556d0f88805