### PR TITLE
Add round-trip test for CLLocationCoordinate2D JSON

### DIFF
--- a/Sources/MapTilerSDK/Helpers/Coordinates.swift
+++ b/Sources/MapTilerSDK/Helpers/Coordinates.swift
@@ -34,8 +34,8 @@ extension CLLocationCoordinate2D: Codable {
 
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        let latitude = try container.decode(CLLocationDegrees.self)
         let longitude = try container.decode(CLLocationDegrees.self)
+        let latitude = try container.decode(CLLocationDegrees.self)
 
         self = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }

--- a/Tests/MapTilerSDKTests/MapTilerSDKTests.swift
+++ b/Tests/MapTilerSDKTests/MapTilerSDKTests.swift
@@ -28,7 +28,17 @@ struct HelperTests {
     @Test func clLocationCoordinate2D_toJSON_notNil() async throws {
         let coordinates = CLLocationCoordinate2D(latitude: 19.2150224, longitude: 44.7569511)
 
-        #expect(coordinates.toJSON() != nil)
+        let jsonString = coordinates.toJSON()
+        #expect(jsonString != nil)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(
+            CLLocationCoordinate2D.self,
+            from: Data(jsonString!.utf8)
+        )
+
+        #expect(decoded.latitude == coordinates.latitude)
+        #expect(decoded.longitude == coordinates.longitude)
     }
 
     @Test func color_toHex_shouldConvertCorrectly() async throws {


### PR DESCRIPTION
## Summary
- Test decoding CLLocationCoordinate2D JSON back to coordinates
- Fix longitude/latitude decoding order for GeoJSON compliance

## Testing
- `swift test` *(fails: no such module 'CoreLocation')*


------
https://chatgpt.com/codex/tasks/task_b_68a45b4eb91c83319a80167f322afe19