### PR TITLE
Fix typos and improve MTMap camera helper

### DIFF
--- a/Sources/MapTilerSDK/Map/Extensions/MTZoomable/MTMapView+MTZoomable.swift
+++ b/Sources/MapTilerSDK/Map/Extensions/MTZoomable/MTMapView+MTZoomable.swift
@@ -3,7 +3,7 @@
 // All rights reserved.
 // SPDX-License-Identifier: BSD 3-Clause
 //
-//  MTMap+MTZoomable.swift
+//  MTMapView+MTZoomable.swift
 //  MapTilerSDK
 //
 

--- a/Sources/MapTilerSDK/Map/MTMapCameraHelper.swift
+++ b/Sources/MapTilerSDK/Map/MTMapCameraHelper.swift
@@ -3,14 +3,14 @@
 // All rights reserved.
 // SPDX-License-Identifier: BSD 3-Clause
 //
-//  MTMapCamera.swift
+//  MTMapCameraHelper.swift
 //  MapTilerSDK
 //
 
 import CoreLocation
 
-/// Sets combination of center, bearing and pitch, as well as roll and elevation.
-public class MTMapCameraHelper {
+/// Sets a combination of center, bearing and pitch, as well as roll and elevation.
+public final class MTMapCameraHelper: Sendable {
     /// The geographical centerpoint of the map.
     ///
     /// If center is not specified, SDK will look for it in the map style object.
@@ -131,7 +131,7 @@ public class MTMapCameraHelper {
 }
 
 extension MTMapCameraHelper {
-    /// Returns boolean inidicating whether camera object is equal to the reciever.
+    /// Returns a Boolean indicating whether the camera object is equal to the receiver.
     /// - Parameters:
     ///   - camera: MTMapCamera object to compare with.
     public func isEqualToMapCameraHelper(_ camera: MTMapCameraHelper) -> Bool {

--- a/Sources/MapTilerSDK/Map/MTMapView.swift
+++ b/Sources/MapTilerSDK/Map/MTMapView.swift
@@ -27,7 +27,7 @@ public protocol MTMapViewDelegate: AnyObject {
     /// Triggers when map is fully initialized.
     func mapViewDidInitialize(_ mapView: MTMapView)
 
-    /// Triggers when event ocurrs.
+    /// Triggers when event occurs.
     func mapView(_ mapView: MTMapView, didTriggerEvent event: MTEvent, with data: MTData?)
 
     /// Triggers when location is updated.
@@ -92,7 +92,7 @@ open class MTMapView: UIView, Sendable {
         commonInit()
     }
 
-    /// Initializes the map with the coder..
+    /// Initializes the map with the coder.
     required public init?(coder: NSCoder) {
         super.init(coder: coder)
 
@@ -127,8 +127,8 @@ open class MTMapView: UIView, Sendable {
 
     /// Initializes location tracking manager.
     ///
-    /// In order to track user location you have to initalize the MLLocationManager,
-    /// add neccessary Privacy Location messages to info.plist, subscribe to MTLocationManagerDelegate
+    /// In order to track user location you have to initialize the MLLocationManager,
+    /// add necessary Privacy Location messages to info.plist, subscribe to MTLocationManagerDelegate
     /// and start location updates and/or request location once via locationManager property on MTMapView.
     /// - Parameters:
     ///    - manager: Optional external CLLocationManager to use.


### PR DESCRIPTION
## Summary
- mark MTMapCameraHelper as `final` and `Sendable`
- fix documentation typos in MTMapView
- correct MTMapView+MTZoomable header comment

## Testing
- `swift test` *(fails: no such module 'CoreLocation')*

------
https://chatgpt.com/codex/tasks/task_b_68a5a51c135483318ce1c580e7a55409